### PR TITLE
bring back generateClaimCode for org

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
+0.5.2
+=====
+* Default name for mode button changed to "Setup".
+* Brought back generateClaimCode for organizations.
+
 0.5.1
 =====
-* NullPointerException fix on setup cancelation.
+* NullPointerException fix on setup cancellation.
 
 0.5.0
 =====

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 =====
 * Default name for mode button changed to "Setup".
 * Brought back generateClaimCode for organizations.
+* Adding customization option for tinting views (spinners, checkmarks, etc.) called element_tint_color.
 
 0.5.1
 =====

--- a/devicesetup/build.gradle
+++ b/devicesetup/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jakewharton.butterknife'
 
 // This is the library version used when deploying the artifact
-version = '0.5.1'
+version = '0.5.2'
 
 ext {
     bintrayRepo = 'android'

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/ConnectingProcessWorkerTask.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/ConnectingProcessWorkerTask.java
@@ -50,8 +50,8 @@ public class ConnectingProcessWorkerTask extends SetupStepsRunnerTask {
                 .build().inject(this);
         this.deviceId = DeviceSetupState.deviceToBeSetUpId;
         this.activityReference = new WeakReference<>(activity);
-        this.tintedSpinner = Ui.getTintedDrawable(activity, R.drawable.progress_spinner, R.color.element_text_color);
-        this.tintedCheckmark = Ui.getTintedDrawable(activity, R.drawable.checkmark, R.color.element_text_color);
+        this.tintedSpinner = Ui.getTintedDrawable(activity, R.drawable.progress_spinner, R.color.element_tint_color);
+        this.tintedCheckmark = Ui.getTintedDrawable(activity, R.drawable.checkmark, R.color.element_tint_color);
     }
 
     @Override

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/GetReadyActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/GetReadyActivity.java
@@ -188,7 +188,8 @@ public class GetReadyActivity extends BaseActivity implements PermissionsFragmen
     private ClaimCodeResponse generateClaimCode(Context ctx) throws ParticleCloudException {
         Resources res = ctx.getResources();
         if (res.getBoolean(R.bool.organization) && !res.getBoolean(R.bool.productMode)) {
-            throw new ParticleCloudException(new Exception("Organization is deprecated, use productMode instead."));
+            return sparkCloud.generateClaimCodeForOrg(res.getString(R.string.organization_slug),
+                    res.getString(R.string.product_slug));
         } else if (res.getBoolean(R.bool.productMode)) {
             int productId = res.getInteger(R.integer.product_id);
             if (productId == 0) {

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/WifiListFragment.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/WifiListFragment.java
@@ -206,17 +206,14 @@ public class WifiListFragment<T extends WifiNetwork> extends ListFragment
                 convertView = LayoutInflater.from(parent.getContext())
                         .inflate(R.layout.row_wifi_scan_result, parent, false);
 
-                // FIXME: remove for branded app, make this tinting configurable or just set it
-                // to white or black automatically, based on whether we're using a light or dark
-                // theme?  Or base it on the color of the text to the left in this row?
                 ImageView theWifi = Ui.findView(convertView, R.id.the_wifi);
                 Drawable whiteWifi = Ui.getTintedDrawable(getContext(), R.drawable.the_wifi,
-                        android.R.color.white);
+                        R.color.element_tint_color);
                 theWifi.setImageDrawable(whiteWifi);
 
                 ImageView securityIcon = Ui.findView(convertView, R.id.wifi_security_indicator_icon);
                 Drawable whiteLock = Ui.getTintedDrawable(getContext(), R.drawable.lock,
-                        android.R.color.white);
+                        R.color.element_tint_color);
                 securityIcon.setImageDrawable(whiteLock);
             }
 

--- a/devicesetup/src/main/java/io/particle/android/sdk/utils/ui/WebViewActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/utils/ui/WebViewActivity.java
@@ -41,9 +41,8 @@ public class WebViewActivity extends AppCompatActivity {
         setContentView(R.layout.activity_web_view);
         SEGAnalytics.track("Device Setup: Webview Screen");
         Toolbar toolbar = Ui.findView(this, R.id.toolbar);
-        // FIXME: that color probably shouldn't be hardcoded, it should use a theme attr.
         toolbar.setNavigationIcon(
-                Ui.getTintedDrawable(this, R.drawable.ic_clear_black_24dp, android.R.color.white));
+                Ui.getTintedDrawable(this, R.drawable.ic_clear_black_24dp, R.color.element_tint_color));
 
         toolbar.setNavigationOnClickListener(view -> finish());
 

--- a/devicesetup/src/main/res/values/customization.xml
+++ b/devicesetup/src/main/res/values/customization.xml
@@ -12,7 +12,7 @@
     <drawable name="screen_background">@drawable/trianglifybackground</drawable>
     <color name="brand_image_background_color">#641A1A1A</color>
 
-    <string name="mode_button_name">Mode button</string>
+    <string name="mode_button_name">Setup button</string>
     <string name="listen_mode_led_color_name">blue</string>
     <string name="network_name_prefix">@string/device_name</string>
 
@@ -45,6 +45,7 @@
     <color name="element_background_color">#00BAEC</color>
     <color name="element_background_color_dark">#0083A6</color>
     <color name="element_text_color">@android:color/white</color>
+    <color name="element_tint_color">@android:color/white</color>
     <color name="element_text_disabled_color">#E0E0E0</color>
 
     <!-- The font names below are the paths to the font you want to use, relative to the assets

--- a/devicesetup/src/main/res/values/devicesetup_styles.xml
+++ b/devicesetup/src/main/res/values/devicesetup_styles.xml
@@ -8,11 +8,6 @@
         <item name="android:layout_width">256dp</item>
         <item name="android:layout_centerHorizontal">true</item>
         <item name="android:layout_gravity">center</item>
-        <!-- FIXME: looks like we got rid of the issue described below.  Verify fix, remove comment-->
-        <!-- Normally it's sort of evil to set margins in a style like this, but thanks to
-            what seems like a bug in the AppCompat theme, the button won't show the
-            touch feedback shadow: it gets clipped by the surrounding view(s) -->
-        <!--        <item name="android:layout_margin">4dp</item>-->
     </style>
 
     <!-- button style to use for our "cram a spinner inside the button's layout bounds" trick -->


### PR DESCRIPTION
* Default name for mode button changed to "Setup".
* Brought back generateClaimCode for organizations.
* Adding customization option for tinting views (spinners, checkmarks, etc.) called element_tint_color.