### PR TITLE
Added ability to inject access token

### DIFF
--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ParticleDeviceSetupLibrary.java
@@ -24,6 +24,29 @@ public class ParticleDeviceSetupLibrary {
     private ApplicationComponent applicationComponent;
 
     /**
+     * The injected access token
+     */
+    protected static String accessToken = null;
+
+    /**
+     * The method for getting a set access token
+     */
+    public static String GetAccessToken()
+    {
+        return accessToken;
+    }
+
+    /**
+     * The method for injecting the access token
+     * <p/>
+     * When the access token is set, the login page is skipped
+     */
+    public static void SetAccessToken(String token)
+    {
+        ParticleDeviceSetupLibrary.accessToken = token;
+    }
+
+    /**
      * The contract for the broadcast sent upon device setup completion.
      * <p/>
      * <em>NOTE: this broadcast will be sent via the LocalBroadcastManager</em>

--- a/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/GetReadyActivity.java
+++ b/devicesetup/src/main/java/io/particle/android/sdk/devicesetup/ui/GetReadyActivity.java
@@ -85,8 +85,13 @@ public class GetReadyActivity extends BaseActivity implements PermissionsFragmen
         softAPConfigRemover.reenableWifiNetworks();
 
         if (sparkCloud.getAccessToken() == null && !BaseActivity.setupOnly) {
-            startLoginActivity();
-            finish();
+            if(ParticleDeviceSetupLibrary.GetAccessToken() != null) {
+                sparkCloud.setAccessToken(ParticleDeviceSetupLibrary.GetAccessToken());
+            }
+            else {
+                startLoginActivity();
+                finish();
+            }
         }
     }
 


### PR DESCRIPTION
**Issue**: Method for injecting an access token (for two-legged authentication) was not clear.  

Our product uses two-legged authentication; we need to inject the customer's access token into the setup process for claiming.  We did not see a clear way to do so.  After some digging, we found that the cloud appears [here ](https://github.com/particle-iot/spark-setup-android/blob/3f5545b782785f64960311dec266faa83b8b3e27/devicesetup/src/main/java/io/particle/android/sdk/di/ApplicationComponent.java#L24) but it is not clear how to set the token.  

This pull request adds a static getter and setter to the `ParticleDeviceSetupLibrary` class for setting the token.  If the token is set, then the setup skips the login.  